### PR TITLE
Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,80 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Every day at midnight UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build-sites:
+    name: Build Sphinx ${{ matrix.site[0] }} site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        site: [[pyodide-kernel-example, pyodide], [xeus-kernel-example, xeus]]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.site[0] }}
+        run: pip install -r requirements.txt
+
+      - name: Build Sphinx site
+        working-directory: ${{ matrix.site[0] }}/docs
+        run: make html
+
+      - name: Upload site artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.site[1] }}
+          path: ${{ matrix.site[0] }}/docs/build/html
+          retention-days: 7
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build-sites
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+      pages: write
+      deployments: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          path: dist
+
+      - name: Sanity check build artifacts
+        run: tree dist
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This PR adds a GitHub Pages site using https://github.com/peaceiris/actions-gh-pages/. It is deployed on pushes to the `main` branch, though I deployed on every commit here for debugging purposes.

The deployments can be accessed via the following links:
- https://jupyterlite.github.io/sphinx-demo/pyodide, for a site that will use the Pyodide kernel
- https://jupyterlite.github.io/sphinx-demo/xeus, for a site that will use the Xeus kernel

I will be iterating on both websites in incoming PRs.