### PR TITLE
Add API reference example pages

### DIFF
--- a/pyodide-kernel-example/README.md
+++ b/pyodide-kernel-example/README.md
@@ -9,6 +9,7 @@ This folder is a JupyterLite deployment with a Sphinx site using the Pyodide ker
 - `docs/source/jupyter_lite_config.json`: a JupyterLite configuration file that allows configuring JupyterLite at build time.
 - `docs/source/jupyter-lite.json`: a JupyterLite configuration file for runtime configuration
 - `docs/source/overrides.json`: a JupyterLite configuration file to configure plugins and other extensions for JupyterLite.
+- `docs/source/try_examples.json`: a JupyterLite configuration file to configure the `TryExamples` directive and buttons; see https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#try-examples-json-configuration-file
 - `docs/source/_static/button_styling.css`: a CSS file to style the buttons added by `jupyterlite-sphinx` in the Sphinx documentation website. This is where you can add your own CSS and style the buttons to match your Sphinx theme. We provide a sample CSS file that fits the PyData Sphinx theme's default colour scheme.
 - `requirements.txt`: the main requirements file. This is where you can specify the dependencies for your Sphinx documentation website.
 

--- a/pyodide-kernel-example/docs/source/apiref.md
+++ b/pyodide-kernel-example/docs/source/apiref.md
@@ -1,0 +1,55 @@
+# API reference interactive example
+
+This page demonstrates `jupyterlite-sphinx`'s integration with NumPy-style docstrings using the [numpydoc](https://numpydoc.readthedocs.io/en/stable/) extension. `jupyterlite-sphinx` supports both `numpydoc` and `sphinx.ext.napoleon`, though the latter is not added in this website.
+
+Here, we showcase the automatic insertion of the `..try_examples::` directive/TryExamples buttons in "Examples" sections when using `numpydoc` for documenting public methods and functions, and common aspects around using them, such as disabling the buttons on a per-docstring and per-page basis.
+
+Please refer to the [`TryExamples` directive documentation](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#other-considerations) for an extended overview of the functionalities offered beyond this demo.
+
+## Features at a glance
+
+1. **Configuring where to display the buttons** – We've set the `global_enable_try_examples` configuration option to `True` in `conf.py`, through which the extension automatically detects Examples sections in docstrings and inserts the `.. try_examples::` directive, which automatically adds the buttons. This works with either `numpydoc` or `sphinx.ext.napoleon` for docstring parsing.
+
+2. **Mathematical equations** – The `solve_pendulum_ode()` function below shows how mathematical equations inside the "Examples" section are rendered with MathJax.
+
+3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `..! disable_try_examples::` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+
+4. **[The `try_examples.json` configuration file](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#try-examples-json-configuration-file)** – this file has been provided in the source directory, where we've set:
+   - a minimum global height for the examples to ensure that the notebooks for examples use a minimum amount of space if the examples sections are small in length.
+   - an ignore pattern for the [Disabled examples](disabled_examples/demo.md) page, so that the buttons are not displayed for any of the examples on that page.
+
+Please refer to the `conf.py` file for the configuration options used in this demo.
+
+## Implementation notes
+
+The examples are displayed as mini-notebooks when users click the `TryExamples` button, with:
+
+- text blocks becoming Markdown cells
+- code blocks becoming executable code cells
+- LaTeX math being rendered using [MathJax](https://www.mathjax.org/)
+- links, if any, being converted from reST to Markdown format
+
+## Module source
+
+Here's the example module that we'll document:
+
+```{eval-rst}
+.. dropdown:: Source code for ``example.py``
+    :icon: code
+    :color: info
+    :animate: fade-in
+
+    .. literalinclude:: example.py
+        :language: python
+        :caption: example.py
+
+```
+
+## Rendered documentation
+
+Now, here's how the documentation for this module is rendered with automatic `TryExamples` buttons, using `numpydoc`:
+
+```{eval-rst}
+.. automodule:: example
+   :members:
+```

--- a/pyodide-kernel-example/docs/source/apiref.md
+++ b/pyodide-kernel-example/docs/source/apiref.md
@@ -12,7 +12,7 @@ Please refer to the [`TryExamples` directive documentation](https://jupyterlite-
 
 2. **Mathematical equations** – The `solve_pendulum_ode()` function below shows how mathematical equations inside the "Examples" section are rendered with MathJax.
 
-3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `..! disable_try_examples` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `.. disable_try_examples` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
 
 4. **[The `try_examples.json` configuration file](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#try-examples-json-configuration-file)** – this file has been provided in the source directory, where we've set:
    - a minimum global height for the examples to ensure that the notebooks for examples use a minimum amount of space if the examples sections are small in length.

--- a/pyodide-kernel-example/docs/source/apiref.md
+++ b/pyodide-kernel-example/docs/source/apiref.md
@@ -12,7 +12,7 @@ Please refer to the [`TryExamples` directive documentation](https://jupyterlite-
 
 2. **Mathematical equations** – The `solve_pendulum_ode()` function below shows how mathematical equations inside the "Examples" section are rendered with MathJax.
 
-3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `..! disable_try_examples::` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `..! disable_try_examples` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
 
 4. **[The `try_examples.json` configuration file](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#try-examples-json-configuration-file)** – this file has been provided in the source directory, where we've set:
    - a minimum global height for the examples to ensure that the notebooks for examples use a minimum amount of space if the examples sections are small in length.

--- a/pyodide-kernel-example/docs/source/conf.py
+++ b/pyodide-kernel-example/docs/source/conf.py
@@ -6,6 +6,10 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import os
+import sys
+
+
 project = "jupyterlite-sphinx-demo"
 copyright = "2025, JupyterLite Contributors"
 author = "JupyterLite Contributors"
@@ -25,6 +29,9 @@ extensions = [
     "numpydoc",
 ]
 
+# To be able to import example.py and disabled_examples/disabled_example.py here
+sys.path.insert(0, os.path.abspath("."))
+sys.path.insert(0, os.path.abspath("disabled_examples"))
 
 templates_path = ["_templates"]
 exclude_patterns = []

--- a/pyodide-kernel-example/docs/source/conf.py
+++ b/pyodide-kernel-example/docs/source/conf.py
@@ -49,6 +49,25 @@ jupyterlite_silence = True
 # Strip out the JupyterLite contents from the output HTML files
 strip_tagged_cells = True
 
+# The global_enable_try_examples configuration option inserts the directives
+# to all "Examples" processed by numpydoc or sphinx.ext.napoleon.
+global_enable_try_examples = True
+
+# The global_button_text configuration option sets the button text for all
+# buttons, and can be overridden in individual TryExamples buttons as well.
+try_examples_global_button_text = "Try it online"
+
+# Considering the experimental nature of the TryExamples feature, this option
+# allows setting a warning message to be displayed as a cell at the top of
+# all interactive examples. This message can be written in Markdown.
+try_examples_global_warning_text = (
+    "This interactive example is experimental. Please report any issues "
+    "you may find to the JupyterLite team via "
+    "[the issue tracker](https://github.com/jupyterlite/sphinx-demo/issues/new). "
+    "Thank you!"
+)
+
+
 # -- Options for MyST-NB -----------------------------------------------------
 
 nb_execution_mode = "auto"

--- a/pyodide-kernel-example/docs/source/conf.py
+++ b/pyodide-kernel-example/docs/source/conf.py
@@ -14,7 +14,17 @@ release = "1.0.0"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["myst_nb", "jupyterlite_sphinx"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
+    "jupyterlite_sphinx",
+    "sphinx_design",
+    "myst_nb",
+    "numpydoc",
+]
+
 
 templates_path = ["_templates"]
 exclude_patterns = []

--- a/pyodide-kernel-example/docs/source/custom_contents/matplotlib_demo.md
+++ b/pyodide-kernel-example/docs/source/custom_contents/matplotlib_demo.md
@@ -37,7 +37,11 @@ so that it won't be included in the JupyterLite deployment.
 
 +++
 
-# Matplotlib interactive demo
+# Notebook-based interactive example
+
+This is an example page to demonstrate how `jupyterlite-sphinx` can be used to create buttons (as noted above) that open a JupyterLite deployment based on Sphinx documentation pages where either the [`.. jupyterlite::`](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/jupyterlite.html) or the [`.. notebooklite::`](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/notebooklite.html) directives are used. Here, we use a [MyST Markdown notebook](https://myst-nb.readthedocs.io/en/v0.9.1/use/markdown.html), however, traditional notebooks based on the `.ipynb` file format are also supported.
+
+## Matplotlib interactive demo
 
 ## Plotting in JupyterLite
 

--- a/pyodide-kernel-example/docs/source/disabled_examples/demo.md
+++ b/pyodide-kernel-example/docs/source/disabled_examples/demo.md
@@ -1,0 +1,30 @@
+---
+orphan: true
+---
+
+# Disabled examples
+
+This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+
+This page is listed in the [`try_examples.json`](../try_examples.json) file, and thus any examples on this page below -will not have the `TryExamples` button displayed.
+
+
+## Example module
+
+```{eval-rst}
+.. dropdown:: Source code for ``disabled_example.py``
+    :icon: code
+    :color: info
+    :animate: fade-in
+
+    .. literalinclude:: disabled_example.py
+
+```
+
+## Rendered documentation
+
+```{eval-rst}
+.. automodule:: disabled_example
+   :members:
+```
+

--- a/pyodide-kernel-example/docs/source/disabled_examples/demo.md
+++ b/pyodide-kernel-example/docs/source/disabled_examples/demo.md
@@ -4,9 +4,18 @@ orphan: true
 
 # Disabled examples
 
-This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a WASM environment.
+This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation on a per-page basis. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a WASM environment.
 
-This page is ignored via a regex pattern in the [`try_examples.json`](../try_examples.json) file, and thus any examples on this page below will not have the `TryExamples` buttons displayed.
+This page is ignored via a regex pattern in the [`try_examples.json`](../try_examples.json) file, like this:
+
+```json
+{
+  "global_min_height": "400px",
+  "ignore_patterns": ["disabled_examples\/demo.html"]
+}
+```
+
+and thus any examples on this page below will not have the `TryExamples` buttons displayed.
 
 
 ## Example module

--- a/pyodide-kernel-example/docs/source/disabled_examples/demo.md
+++ b/pyodide-kernel-example/docs/source/disabled_examples/demo.md
@@ -4,9 +4,9 @@ orphan: true
 
 # Disabled examples
 
-This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a WASM environment.
 
-This page is listed in the [`try_examples.json`](../try_examples.json) file, and thus any examples on this page below -will not have the `TryExamples` button displayed.
+This page is ignored via a regex pattern in the [`try_examples.json`](../try_examples.json) file, and thus any examples on this page below will not have the `TryExamples` buttons displayed.
 
 
 ## Example module

--- a/pyodide-kernel-example/docs/source/disabled_examples/disabled_example.py
+++ b/pyodide-kernel-example/docs/source/disabled_examples/disabled_example.py
@@ -1,0 +1,39 @@
+"""Even though the docstrings in this module contain proper Examples sections in the
+NumPy style format, no TryExamples buttons will be displayed, as this page is
+included in the ignore_patterns list in try_examples.json.
+"""
+
+def square_number(x):
+    """Return the square of a number.
+
+    This simple function demonstrates that even basic examples
+    don't show TryExamples buttons when the page is disabled
+    via try_examples.json.
+
+    Parameters
+    ----------
+    x : number
+        The number to square.
+
+    Returns
+    -------
+    number
+        The square of the input number.
+
+    Examples
+    --------
+    Square some numbers:
+
+    >>> square_number(4)
+    16
+    >>> square_number(2.5)
+    6.25
+
+    Use with a list comprehension:
+
+    >>> numbers = [1, 2, 3, 4, 5]
+    >>> squares = [square_number(n) for n in numbers]
+    >>> print(squares)
+    [1, 4, 9, 16, 25]
+    """
+    return x * x

--- a/pyodide-kernel-example/docs/source/disabled_examples/disabled_example.py
+++ b/pyodide-kernel-example/docs/source/disabled_examples/disabled_example.py
@@ -1,14 +1,10 @@
-"""Even though the docstrings in this module contain proper Examples sections in the
-NumPy style format, no TryExamples buttons will be displayed, as this page is
+"""Even though the docstrings in the function below contain Examples sections in
+the NumPy style format, no TryExamples buttons will be displayed, as this page is
 included in the ignore_patterns list in try_examples.json.
 """
 
 def square_number(x):
     """Return the square of a number.
-
-    This simple function demonstrates that even basic examples
-    don't show TryExamples buttons when the page is disabled
-    via try_examples.json.
 
     Parameters
     ----------

--- a/pyodide-kernel-example/docs/source/example.py
+++ b/pyodide-kernel-example/docs/source/example.py
@@ -259,7 +259,7 @@ def image_processing(image):
     """Process an image with various transformations.
 
     This function has the TryExamples button explicitly disabled using
-    the '..! disable_try_examples' comment at the beginning of the
+    the `.. disable_try_examples` comment at the beginning of the
     Examples section.
 
     Parameters
@@ -275,7 +275,7 @@ def image_processing(image):
     Examples
     --------
 
-    ..! disable_try_examples
+    .. disable_try_examples
 
     Generate and process synthetic images:
 

--- a/pyodide-kernel-example/docs/source/example.py
+++ b/pyodide-kernel-example/docs/source/example.py
@@ -1,0 +1,332 @@
+"""Here are some utility functions for ``jupyterlite-sphinx-demo``.
+
+This module contains example functions with NumPy-style docstrings,
+whose Examples sections include code snippets that can be executed
+interactively with a button to open a JupyterLite session.
+
+The examples below are designed to be simple and self-contained.
+"""
+
+import numpy as np
+from scipy.integrate import solve_ivp
+import pandas as pd
+
+
+def fibonacci_sequence(n):
+    """Generate a Fibonacci sequence up to the nth term.
+
+    This function demonstrates basic NumPy docstrings with a simple
+    mathematical function and an interactive example.
+
+    Parameters
+    ----------
+    n : int
+        Number of terms to generate.
+
+    Returns
+    -------
+    list
+        List containing the Fibonacci sequence up to the nth term.
+
+    Examples
+    --------
+    Use NumPy to create and analyze a sequence:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> # Create a sequence
+    >>> x = np.arange(1, 11)
+    >>> y = np.power(x, 2)
+    >>> print(y)
+    [  1   4   9  16  25  36  49  64  81 100]
+
+    Plot the sequence:
+
+    >>> plt.figure(figsize=(8, 4))
+    >>> plt.plot(x, y, 'o-', linewidth=2)
+    >>> plt.title('Square Numbers')
+    >>> plt.xlabel('n')
+    >>> plt.ylabel('n²')
+    >>> plt.grid(True)
+    >>> plt.show()
+    """
+    if not isinstance(n, int) or n <= 0:
+        raise ValueError("n must be a positive integer")
+
+    fibonacci = [0, 1]
+    if n <= 2:
+        return fibonacci[:n]
+
+    for i in range(2, n):
+        fibonacci.append(fibonacci[i - 1] + fibonacci[i - 2])
+
+    return fibonacci
+
+
+def analyze_data(data, column=None, bins=10):
+    """Analyze numerical data with descriptive statistics and visualization.
+
+    This function demonstrates more complex docstrings with various
+    visualization options in the examples section.
+
+    Parameters
+    ----------
+    data : array_like or pandas.DataFrame
+        The numerical data to analyze.
+    column : str, optional
+        If data is a DataFrame, specify the column to analyze.
+    bins : int, default 10
+        Number of bins for the histogram.
+
+    Returns
+    -------
+    dict
+        Dictionary containing descriptive statistics:
+        - 'mean': The mean of the data
+        - 'median': The median of the data
+        - 'std': The standard deviation of the data
+        - 'min': The minimum value
+        - 'max': The maximum value
+
+    Examples
+    --------
+    Generate and analyze random data:
+
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> np.random.seed(42)
+    >>> data = np.random.normal(loc=5, scale=2, size=1000)
+    >>>
+    >>> # Calculate statistics using NumPy
+    >>> mean = np.mean(data)
+    >>> median = np.median(data)
+    >>> std = np.std(data)
+    >>> min_val = np.min(data)
+    >>> max_val = np.max(data)
+    >>>
+    >>> print(f"Mean: {mean:.2f}, Median: {median:.2f}")
+    Mean: 5.04, Median: 5.04
+
+    Create and explore a DataFrame:
+
+    >>> df = pd.DataFrame({
+    ...     'temperature': np.random.normal(25, 5, 100),
+    ...     'humidity': np.random.normal(60, 10, 100)
+    ... })
+    >>> print(df.describe())
+           temperature     humidity
+    count  100.000000  100.000000
+    mean    25.227...   59.935...
+    std      4.916...    9.076...
+    min     15.090...   36.670...
+    25%     21.421...   53.133...
+    50%     25.354...   60.585...
+    75%     28.752...   65.789...
+    max     37.937...   82.882...
+
+    Visualize the data with a histogram and KDE:
+
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy import stats
+    >>> plt.figure(figsize=(10, 6))
+    >>> plt.hist(data, bins=20, alpha=0.7, density=True)
+    >>> x = np.linspace(data.min(), data.max(), 100)
+    >>> kde = stats.gaussian_kde(data)
+    >>> plt.plot(x, kde(x), 'r-', linewidth=2)
+    >>> plt.title('Data Distribution')
+    >>> plt.xlabel('Value')
+    >>> plt.ylabel('Density')
+    >>> plt.grid(True, alpha=0.3)
+    >>> plt.show()
+    """
+    # Convert to numpy array if necessary
+    if isinstance(data, pd.DataFrame):
+        if column is None:
+            raise ValueError("Column must be specified when data is a DataFrame")
+        values = data[column].values
+    else:
+        values = np.asarray(data)
+
+    # Calculate statistics
+    stats = {
+        "mean": np.mean(values),
+        "median": np.median(values),
+        "std": np.std(values),
+        "min": np.min(values),
+        "max": np.max(values),
+    }
+
+    return stats
+
+
+def solve_pendulum_ode(theta0=np.pi / 4, omega0=0, t_span=(0, 10), g=9.8, L=1.0):
+    """Solve the differential equation for a simple pendulum.
+
+    This function uses of mathematical equations in docstrings. ``jupyterlite-sphinx``
+    is able to convert LaTeX syntax for use with MathJax for rendering in the documentation.
+
+    Parameters
+    ----------
+    theta0 : float, default π/4
+        Initial angle in radians.
+    omega0 : float, default 0
+        Initial angular velocity in radians/second.
+    t_span : tuple of (float, float), default (0, 10)
+        Time interval (start, end) for the simulation.
+    g : float, default 9.8
+        Acceleration due to gravity in m/s².
+    L : float, default 1.0
+        Length of the pendulum in meters.
+
+    Returns
+    -------
+    tuple
+        (t, y) where t is the time points and y is the solution array with
+        columns [theta, omega].
+
+    Examples
+    --------
+    Simulate a damped harmonic oscillator, governed by the second-order
+    differential equation:
+
+    .. math::
+        \\frac{d^2\\theta}{dt^2} + \\frac{g}{L}\\sin(\\theta) = 0
+
+    where
+
+    1. :math:`\\theta` is the angle from the vertical position
+    2. :math:`g` is the acceleration due to gravity
+    3. :math:`L` is the length of the pendulum
+
+    >>> import numpy as np
+    >>> from scipy.integrate import solve_ivp
+    >>> import matplotlib.pyplot as plt
+    >>>
+    >>> def harmonic_oscillator(t, y, k=1.0, m=1.0, c=0.1):
+    ...     # Simple harmonic oscillator with damping
+    ...     # y[0] is position, y[1] is velocity
+    ...     return [y[1], -k/m * y[0] - c/m * y[1]]
+    >>>
+    >>> # Initial conditions: position = 1, velocity = 0
+    >>> y0 = [1.0, 0.0]
+    >>>
+    >>> ### Solving the ODE
+    >>> t_span = (0, 20)
+    >>> t_eval = np.linspace(t_span[0], t_span[1], 500)
+    >>> sol = solve_ivp(harmonic_oscillator, t_span, y0, method='RK45', t_eval=t_eval)
+    >>>
+    >>> ### Plotting the results
+    >>> plt.figure(figsize=(10, 6))
+    >>> plt.subplot(2, 1, 1)
+    >>> plt.plot(sol.t, sol.y[0])
+    >>> plt.title('Damped Harmonic Oscillator')
+    >>> plt.ylabel('Position')
+    >>> plt.grid(True)
+    >>>
+    >>> plt.subplot(2, 1, 2)
+    >>> plt.plot(sol.t, sol.y[1])
+    >>> plt.xlabel('Time (s)')
+    >>> plt.ylabel('Velocity')
+    >>> plt.grid(True)
+    >>> plt.tight_layout()
+    >>> plt.show()
+    >>>
+    >>> # A phase space plot
+    >>> plt.figure(figsize=(8, 8))
+    >>> plt.plot(sol.y[0], sol.y[1])
+    >>> plt.title('Phase Space')
+    >>> plt.xlabel('Position')
+    >>> plt.ylabel('Velocity')
+    >>> plt.grid(True)
+    >>> plt.axis('equal')
+    >>> plt.show()
+    """
+
+    def pendulum_system(t, y):
+        theta, omega = y
+        dydt = [omega, -(g / L) * np.sin(theta)]
+        return dydt
+
+    y0 = [theta0, omega0]
+    t_eval = np.linspace(t_span[0], t_span[1], 500)
+
+    sol = solve_ivp(pendulum_system, t_span, y0, method="RK45", t_eval=t_eval)
+
+    return sol.t, sol.y.T
+
+
+def image_processing(image):
+    """Process an image with various transformations.
+
+    This function has the TryExamples button explicitly disabled using
+    the '..! disable_try_examples::' comment at the beginning of the
+    Examples section.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image as a numpy array.
+
+    Returns
+    -------
+    dict
+        Dictionary containing various processed versions of the image.
+
+    Examples
+    --------
+
+    ..! disable_try_examples::
+
+    Generate and process synthetic images:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from matplotlib.colors import LinearSegmentedColormap
+    >>>
+    >>> # Create a simple synthetic image
+    >>> x = np.linspace(-3, 3, 100)
+    >>> y = np.linspace(-3, 3, 100)
+    >>> X, Y = np.meshgrid(x, y)
+    >>> Z = np.sin(X) * np.cos(Y)
+    >>>
+    >>> # Display the image
+    >>> plt.figure(figsize=(12, 10))
+    >>> plt.subplot(2, 2, 1)
+    >>> plt.imshow(Z, cmap='viridis')
+    >>> plt.title('Original')
+    >>> plt.colorbar()
+    >>>
+    >>> ### Apply some transformations
+    >>> # 1. Add some noise
+    >>> Z_noisy = Z + np.random.normal(0, 0.2, Z.shape)
+    >>> plt.subplot(2, 2, 2)
+    >>> plt.imshow(Z_noisy, cmap='viridis')
+    >>> plt.title('With Noise')
+    >>> plt.colorbar()
+    >>>
+    >>> # 2. Apply a filter (for smoothing)
+    >>> from scipy.ndimage import gaussian_filter
+    >>> Z_smooth = gaussian_filter(Z, sigma=1)
+    >>> plt.subplot(2, 2, 3)
+    >>> plt.imshow(Z_smooth, cmap='viridis')
+    >>> plt.title('Smoothed')
+    >>> plt.colorbar()
+    >>>
+    >>> # 3. Perform edge detection
+    >>> from scipy.ndimage import sobel
+    >>> Z_edges = sobel(Z)
+    >>> plt.subplot(2, 2, 4)
+    >>> plt.imshow(Z_edges, cmap='gray')
+    >>> plt.title('Edges')
+    >>> plt.colorbar()
+    >>>
+    >>> plt.tight_layout()
+    >>> plt.show()
+    """
+    from skimage import color, filters
+
+    grayscale = color.rgb2gray(image)
+    blurred = filters.gaussian(image, sigma=2, multichannel=True)
+    edges = filters.sobel(grayscale)
+
+    return {"grayscale": grayscale, "blurred": blurred, "edges": edges}

--- a/pyodide-kernel-example/docs/source/example.py
+++ b/pyodide-kernel-example/docs/source/example.py
@@ -259,7 +259,7 @@ def image_processing(image):
     """Process an image with various transformations.
 
     This function has the TryExamples button explicitly disabled using
-    the '..! disable_try_examples::' comment at the beginning of the
+    the '..! disable_try_examples' comment at the beginning of the
     Examples section.
 
     Parameters
@@ -275,7 +275,7 @@ def image_processing(image):
     Examples
     --------
 
-    ..! disable_try_examples::
+    ..! disable_try_examples
 
     Generate and process synthetic images:
 

--- a/pyodide-kernel-example/docs/source/index.md
+++ b/pyodide-kernel-example/docs/source/index.md
@@ -5,7 +5,9 @@
 
 # `jupyterlite-sphinx-demo`
 
-This website provides an end-to-end demo of the `jupyterlite-sphinx` extension, which allows you to integrate a JupyterLite deployment as a part of a Sphinx documentation website. It is meant to be used as a reference for documentation website authors who want to add interactive documentation elements to their Sphinx sites. This demo uses the Pyodide kernel; for a demo using the Xeus kernel, please switch to the `xeus` site using the selector dropdown in the navigation bar.
+This website provides an end-to-end demo of the `jupyterlite-sphinx` extension, which allows you to integrate a JupyterLite deployment as a part of a Sphinx documentation website. It is meant to be used as a reference for documentation website authors who want to add interactive documentation elements to their Sphinx sites.
+
+This demo uses the Pyodide kernel; for a demo using the Xeus kernel, please switch to the `xeus` site using the selector dropdown in the navigation bar.
 
 The demo has been organised into the following sections, each of which demonstrates a different feature of the Sphinx extension:
 
@@ -14,4 +16,5 @@ The demo has been organised into the following sections, each of which demonstra
 :maxdepth: 1
 
 custom_contents/matplotlib_demo.md
+apiref.md
 ```

--- a/pyodide-kernel-example/docs/source/try_examples.json
+++ b/pyodide-kernel-example/docs/source/try_examples.json
@@ -1,0 +1,4 @@
+{
+  "global_min_height": "400px",
+  "ignore_patterns": ["disabled_examples\/demo.html"]
+}

--- a/pyodide-kernel-example/requirements.txt
+++ b/pyodide-kernel-example/requirements.txt
@@ -16,3 +16,6 @@ myst-nb
 
 # Dependencies we require for notebook execution
 matplotlib
+
+# Dependencies we require for API reference generation
+numpydoc

--- a/pyodide-kernel-example/requirements.txt
+++ b/pyodide-kernel-example/requirements.txt
@@ -1,6 +1,6 @@
 
 # jupyterlite-sphinx brings jupyterlite-core and JupyterLite-specific dependencies.
-jupyterlite-sphinx
+jupyterlite-sphinx>=0.20.0
 
 # The Pyodide kernel version controls the Pyodide version as a part of the interactive
 # documentation deployment. Please refer to the Compatibility section at

--- a/pyodide-kernel-example/requirements.txt
+++ b/pyodide-kernel-example/requirements.txt
@@ -7,6 +7,8 @@ jupyterlite-sphinx
 # https://jupyterlite-pyodide-kernel.readthedocs.io/en/latest/#compatibility.
 jupyterlite-pyodide-kernel==0.5.2
 
+###############################################################################
+
 # The Sphinx documentation framework and our theme of choice: the PyData Sphinx Theme
 sphinx
 pydata-sphinx-theme
@@ -16,6 +18,12 @@ myst-nb
 
 # Dependencies we require for notebook execution
 matplotlib
+numpy
+scikit-image
+scipy
 
 # Dependencies we require for API reference generation
 numpydoc
+
+# Other Sphinx extensions
+sphinx-design

--- a/pyodide-kernel-example/requirements.txt
+++ b/pyodide-kernel-example/requirements.txt
@@ -21,6 +21,7 @@ matplotlib
 numpy
 scikit-image
 scipy
+pandas
 
 # Dependencies we require for API reference generation
 numpydoc

--- a/xeus-kernel-example/README.md
+++ b/xeus-kernel-example/README.md
@@ -9,6 +9,7 @@ This folder is a JupyterLite deployment with a Sphinx site using the Xeus loader
 - `docs/source/jupyter_lite_config.json`: a JupyterLite configuration file that allows configuring JupyterLite at build time.
 - `docs/source/jupyter-lite.json`: a JupyterLite configuration file for runtime configuration
 - `docs/source/overrides.json`: a JupyterLite configuration file to configure plugins and other extensions for JupyterLite.
+- `docs/source/try_examples.json`: a JupyterLite configuration file to configure the `TryExamples` directive and buttons; see https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#try-examples-json-configuration-file
 - `docs/source/environment.yml`: the environment file that is used install the in-browser dependencies for the kernel at the time of building the JupyterLite deployment within the Sphinx build process.
 - `docs/source/_static/button_styling.css`: a CSS file to style the buttons added by `jupyterlite-sphinx` in the Sphinx documentation website. This is where you can add your own CSS and style the buttons to match your Sphinx theme. We provide a sample CSS file that fits the PyData Sphinx theme's default colour scheme.
 - `requirements.txt`: the main requirements file. This is where you can specify the dependencies for your Sphinx documentation website.

--- a/xeus-kernel-example/docs/source/apiref.md
+++ b/xeus-kernel-example/docs/source/apiref.md
@@ -1,0 +1,55 @@
+# API reference interactive example
+
+This page demonstrates `jupyterlite-sphinx`'s integration with NumPy-style docstrings using the [numpydoc](https://numpydoc.readthedocs.io/en/stable/) extension. `jupyterlite-sphinx` supports both `numpydoc` and `sphinx.ext.napoleon`, though the latter is not added in this website.
+
+Here, we showcase the automatic insertion of the `..try_examples::` directive/TryExamples buttons in "Examples" sections when using `numpydoc` for documenting public methods and functions, and common aspects around using them, such as disabling the buttons on a per-docstring and per-page basis.
+
+Please refer to the [`TryExamples` directive documentation](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#other-considerations) for an extended overview of the functionalities offered beyond this demo.
+
+## Features at a glance
+
+1. **Configuring where to display the buttons** – We've set the `global_enable_try_examples` configuration option to `True` in `conf.py`, through which the extension automatically detects Examples sections in docstrings and inserts the `.. try_examples::` directive, which automatically adds the buttons. This works with either `numpydoc` or `sphinx.ext.napoleon` for docstring parsing.
+
+2. **Mathematical equations** – The `solve_pendulum_ode()` function below shows how mathematical equations inside the "Examples" section are rendered with MathJax.
+
+3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `..! disable_try_examples::` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+
+4. **[The `try_examples.json` configuration file](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#try-examples-json-configuration-file)** – this file has been provided in the source directory, where we've set:
+   - a minimum global height for the examples to ensure that the notebooks for examples use a minimum amount of space if the examples sections are small in length.
+   - an ignore pattern for the [Disabled examples](disabled_examples/demo.md) page, so that the buttons are not displayed for any of the examples on that page.
+
+Please refer to the `conf.py` file for the configuration options used in this demo.
+
+## Implementation notes
+
+The examples are displayed as mini-notebooks when users click the `TryExamples` button, with:
+
+- text blocks becoming Markdown cells
+- code blocks becoming executable code cells
+- LaTeX math being rendered using [MathJax](https://www.mathjax.org/)
+- links, if any, being converted from reST to Markdown format
+
+## Module source
+
+Here's the example module that we'll document:
+
+```{eval-rst}
+.. dropdown:: Source code for ``example.py``
+    :icon: code
+    :color: info
+    :animate: fade-in
+
+    .. literalinclude:: example.py
+        :language: python
+        :caption: example.py
+
+```
+
+## Rendered documentation
+
+Now, here's how the documentation for this module is rendered with automatic `TryExamples` buttons, using `numpydoc`:
+
+```{eval-rst}
+.. automodule:: example
+   :members:
+```

--- a/xeus-kernel-example/docs/source/apiref.md
+++ b/xeus-kernel-example/docs/source/apiref.md
@@ -12,7 +12,7 @@ Please refer to the [`TryExamples` directive documentation](https://jupyterlite-
 
 2. **Mathematical equations** – The `solve_pendulum_ode()` function below shows how mathematical equations inside the "Examples" section are rendered with MathJax.
 
-3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `..! disable_try_examples` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `.. disable_try_examples` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
 
 4. **[The `try_examples.json` configuration file](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#try-examples-json-configuration-file)** – this file has been provided in the source directory, where we've set:
    - a minimum global height for the examples to ensure that the notebooks for examples use a minimum amount of space if the examples sections are small in length.

--- a/xeus-kernel-example/docs/source/apiref.md
+++ b/xeus-kernel-example/docs/source/apiref.md
@@ -12,7 +12,7 @@ Please refer to the [`TryExamples` directive documentation](https://jupyterlite-
 
 2. **Mathematical equations** – The `solve_pendulum_ode()` function below shows how mathematical equations inside the "Examples" section are rendered with MathJax.
 
-3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `..! disable_try_examples::` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+3. **Disabling the buttons** – The `image_processing()` function's docstring below contains the `..! disable_try_examples` comment, which disables the automatic insertion of the directive/buttons. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
 
 4. **[The `try_examples.json` configuration file](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/try_examples.html#try-examples-json-configuration-file)** – this file has been provided in the source directory, where we've set:
    - a minimum global height for the examples to ensure that the notebooks for examples use a minimum amount of space if the examples sections are small in length.

--- a/xeus-kernel-example/docs/source/conf.py
+++ b/xeus-kernel-example/docs/source/conf.py
@@ -6,6 +6,10 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import os
+import sys
+
+
 project = "jupyterlite-sphinx-demo"
 copyright = "2025, JupyterLite Contributors"
 author = "JupyterLite Contributors"
@@ -25,6 +29,9 @@ extensions = [
     "numpydoc",
 ]
 
+# To be able to import example.py and disabled_examples/disabled_example.py here
+sys.path.insert(0, os.path.abspath("."))
+sys.path.insert(0, os.path.abspath("disabled_examples"))
 
 templates_path = ["_templates"]
 exclude_patterns = []

--- a/xeus-kernel-example/docs/source/conf.py
+++ b/xeus-kernel-example/docs/source/conf.py
@@ -49,6 +49,25 @@ jupyterlite_silence = True
 # Strip out the JupyterLite contents from the output HTML files
 strip_tagged_cells = True
 
+# The global_enable_try_examples configuration option inserts the directives
+# to all "Examples" processed by numpydoc or sphinx.ext.napoleon.
+global_enable_try_examples = True
+
+# The global_button_text configuration option sets the button text for all
+# buttons, and can be overridden in individual TryExamples buttons as well.
+try_examples_global_button_text = "Try it online"
+
+# Considering the experimental nature of the TryExamples feature, this option
+# allows setting a warning message to be displayed as a cell at the top of
+# all interactive examples. This message can be written in Markdown.
+try_examples_global_warning_text = (
+    "This interactive example is experimental. Please report any issues "
+    "you may find to the JupyterLite team via "
+    "[the issue tracker](https://github.com/jupyterlite/sphinx-demo/issues/new). "
+    "Thank you!"
+)
+
+
 # -- Options for MyST-NB -----------------------------------------------------
 
 nb_execution_mode = "auto"

--- a/xeus-kernel-example/docs/source/conf.py
+++ b/xeus-kernel-example/docs/source/conf.py
@@ -14,7 +14,17 @@ release = "1.0.0"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["myst_nb", "jupyterlite_sphinx"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
+    "jupyterlite_sphinx",
+    "sphinx_design",
+    "myst_nb",
+    "numpydoc",
+]
+
 
 templates_path = ["_templates"]
 exclude_patterns = []

--- a/xeus-kernel-example/docs/source/custom_contents/matplotlib_demo.md
+++ b/xeus-kernel-example/docs/source/custom_contents/matplotlib_demo.md
@@ -36,7 +36,11 @@ so that it won't be included in the JupyterLite deployment.
 
 +++
 
-# Matplotlib interactive demo
+# Notebook-based interactive example
+
+This is an example page to demonstrate how `jupyterlite-sphinx` can be used to create buttons (as noted above) that open a JupyterLite deployment based on Sphinx documentation pages where either the [`.. jupyterlite::`](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/jupyterlite.html) or the [`.. notebooklite::`](https://jupyterlite-sphinx.readthedocs.io/en/stable/directives/notebooklite.html) directives are used. Here, we use a [MyST Markdown notebook](https://myst-nb.readthedocs.io/en/v0.9.1/use/markdown.html), however, traditional notebooks based on the `.ipynb` file format are also supported.
+
+## Matplotlib interactive demo
 
 ## Plotting in JupyterLite
 

--- a/xeus-kernel-example/docs/source/disabled_examples/demo.md
+++ b/xeus-kernel-example/docs/source/disabled_examples/demo.md
@@ -1,0 +1,30 @@
+---
+orphan: true
+---
+
+# Disabled examples
+
+This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+
+This page is listed in the [`try_examples.json`](../try_examples.json) file, and thus any examples on this page below -will not have the `TryExamples` button displayed.
+
+
+## Example module
+
+```{eval-rst}
+.. dropdown:: Source code for ``disabled_example.py``
+    :icon: code
+    :color: info
+    :animate: fade-in
+
+    .. literalinclude:: disabled_example.py
+
+```
+
+## Rendered documentation
+
+```{eval-rst}
+.. automodule:: disabled_example
+   :members:
+```
+

--- a/xeus-kernel-example/docs/source/disabled_examples/demo.md
+++ b/xeus-kernel-example/docs/source/disabled_examples/demo.md
@@ -4,9 +4,18 @@ orphan: true
 
 # Disabled examples
 
-This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a WASM environment.
+This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation on a per-page basis. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a WASM environment.
 
-This page is ignored via a regex pattern in the [`try_examples.json`](../try_examples.json) file, and thus any examples on this page below will not have the `TryExamples` buttons displayed.
+This page is ignored via a regex pattern in the [`try_examples.json`](../try_examples.json) file, like this:
+
+```json
+{
+  "global_min_height": "400px",
+  "ignore_patterns": ["disabled_examples\/demo.html"]
+}
+```
+
+and thus any examples on this page below will not have the `TryExamples` buttons displayed.
 
 
 ## Example module

--- a/xeus-kernel-example/docs/source/disabled_examples/demo.md
+++ b/xeus-kernel-example/docs/source/disabled_examples/demo.md
@@ -4,9 +4,9 @@ orphan: true
 
 # Disabled examples
 
-This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a notebook environment.
+This page is intended to show how to disable the automatic insertion of the `TryExamples` button in the documentation. This is useful for methods that are not intended to be executed interactively or for those that may not work well in a WASM environment.
 
-This page is listed in the [`try_examples.json`](../try_examples.json) file, and thus any examples on this page below -will not have the `TryExamples` button displayed.
+This page is ignored via a regex pattern in the [`try_examples.json`](../try_examples.json) file, and thus any examples on this page below will not have the `TryExamples` buttons displayed.
 
 
 ## Example module

--- a/xeus-kernel-example/docs/source/disabled_examples/disabled_example.py
+++ b/xeus-kernel-example/docs/source/disabled_examples/disabled_example.py
@@ -1,0 +1,39 @@
+"""Even though the docstrings in this module contain proper Examples sections in the
+NumPy style format, no TryExamples buttons will be displayed, as this page is
+included in the ignore_patterns list in try_examples.json.
+"""
+
+def square_number(x):
+    """Return the square of a number.
+
+    This simple function demonstrates that even basic examples
+    don't show TryExamples buttons when the page is disabled
+    via try_examples.json.
+
+    Parameters
+    ----------
+    x : number
+        The number to square.
+
+    Returns
+    -------
+    number
+        The square of the input number.
+
+    Examples
+    --------
+    Square some numbers:
+
+    >>> square_number(4)
+    16
+    >>> square_number(2.5)
+    6.25
+
+    Use with a list comprehension:
+
+    >>> numbers = [1, 2, 3, 4, 5]
+    >>> squares = [square_number(n) for n in numbers]
+    >>> print(squares)
+    [1, 4, 9, 16, 25]
+    """
+    return x * x

--- a/xeus-kernel-example/docs/source/disabled_examples/disabled_example.py
+++ b/xeus-kernel-example/docs/source/disabled_examples/disabled_example.py
@@ -1,14 +1,10 @@
-"""Even though the docstrings in this module contain proper Examples sections in the
-NumPy style format, no TryExamples buttons will be displayed, as this page is
+"""Even though the docstrings in the function below contain Examples sections in
+the NumPy style format, no TryExamples buttons will be displayed, as this page is
 included in the ignore_patterns list in try_examples.json.
 """
 
 def square_number(x):
     """Return the square of a number.
-
-    This simple function demonstrates that even basic examples
-    don't show TryExamples buttons when the page is disabled
-    via try_examples.json.
 
     Parameters
     ----------

--- a/xeus-kernel-example/docs/source/example.py
+++ b/xeus-kernel-example/docs/source/example.py
@@ -259,7 +259,7 @@ def image_processing(image):
     """Process an image with various transformations.
 
     This function has the TryExamples button explicitly disabled using
-    the '..! disable_try_examples' comment at the beginning of the
+    the `.. disable_try_examples` comment at the beginning of the
     Examples section.
 
     Parameters
@@ -275,7 +275,7 @@ def image_processing(image):
     Examples
     --------
 
-    ..! disable_try_examples
+    .. disable_try_examples
 
     Generate and process synthetic images:
 

--- a/xeus-kernel-example/docs/source/example.py
+++ b/xeus-kernel-example/docs/source/example.py
@@ -1,0 +1,332 @@
+"""Here are some utility functions for ``jupyterlite-sphinx-demo``.
+
+This module contains example functions with NumPy-style docstrings,
+whose Examples sections include code snippets that can be executed
+interactively with a button to open a JupyterLite session.
+
+The examples below are designed to be simple and self-contained.
+"""
+
+import numpy as np
+from scipy.integrate import solve_ivp
+import pandas as pd
+
+
+def fibonacci_sequence(n):
+    """Generate a Fibonacci sequence up to the nth term.
+
+    This function demonstrates basic NumPy docstrings with a simple
+    mathematical function and an interactive example.
+
+    Parameters
+    ----------
+    n : int
+        Number of terms to generate.
+
+    Returns
+    -------
+    list
+        List containing the Fibonacci sequence up to the nth term.
+
+    Examples
+    --------
+    Use NumPy to create and analyze a sequence:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> # Create a sequence
+    >>> x = np.arange(1, 11)
+    >>> y = np.power(x, 2)
+    >>> print(y)
+    [  1   4   9  16  25  36  49  64  81 100]
+
+    Plot the sequence:
+
+    >>> plt.figure(figsize=(8, 4))
+    >>> plt.plot(x, y, 'o-', linewidth=2)
+    >>> plt.title('Square Numbers')
+    >>> plt.xlabel('n')
+    >>> plt.ylabel('n²')
+    >>> plt.grid(True)
+    >>> plt.show()
+    """
+    if not isinstance(n, int) or n <= 0:
+        raise ValueError("n must be a positive integer")
+
+    fibonacci = [0, 1]
+    if n <= 2:
+        return fibonacci[:n]
+
+    for i in range(2, n):
+        fibonacci.append(fibonacci[i - 1] + fibonacci[i - 2])
+
+    return fibonacci
+
+
+def analyze_data(data, column=None, bins=10):
+    """Analyze numerical data with descriptive statistics and visualization.
+
+    This function demonstrates more complex docstrings with various
+    visualization options in the examples section.
+
+    Parameters
+    ----------
+    data : array_like or pandas.DataFrame
+        The numerical data to analyze.
+    column : str, optional
+        If data is a DataFrame, specify the column to analyze.
+    bins : int, default 10
+        Number of bins for the histogram.
+
+    Returns
+    -------
+    dict
+        Dictionary containing descriptive statistics:
+        - 'mean': The mean of the data
+        - 'median': The median of the data
+        - 'std': The standard deviation of the data
+        - 'min': The minimum value
+        - 'max': The maximum value
+
+    Examples
+    --------
+    Generate and analyze random data:
+
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> np.random.seed(42)
+    >>> data = np.random.normal(loc=5, scale=2, size=1000)
+    >>>
+    >>> # Calculate statistics using NumPy
+    >>> mean = np.mean(data)
+    >>> median = np.median(data)
+    >>> std = np.std(data)
+    >>> min_val = np.min(data)
+    >>> max_val = np.max(data)
+    >>>
+    >>> print(f"Mean: {mean:.2f}, Median: {median:.2f}")
+    Mean: 5.04, Median: 5.04
+
+    Create and explore a DataFrame:
+
+    >>> df = pd.DataFrame({
+    ...     'temperature': np.random.normal(25, 5, 100),
+    ...     'humidity': np.random.normal(60, 10, 100)
+    ... })
+    >>> print(df.describe())
+           temperature     humidity
+    count  100.000000  100.000000
+    mean    25.227...   59.935...
+    std      4.916...    9.076...
+    min     15.090...   36.670...
+    25%     21.421...   53.133...
+    50%     25.354...   60.585...
+    75%     28.752...   65.789...
+    max     37.937...   82.882...
+
+    Visualize the data with a histogram and KDE:
+
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy import stats
+    >>> plt.figure(figsize=(10, 6))
+    >>> plt.hist(data, bins=20, alpha=0.7, density=True)
+    >>> x = np.linspace(data.min(), data.max(), 100)
+    >>> kde = stats.gaussian_kde(data)
+    >>> plt.plot(x, kde(x), 'r-', linewidth=2)
+    >>> plt.title('Data Distribution')
+    >>> plt.xlabel('Value')
+    >>> plt.ylabel('Density')
+    >>> plt.grid(True, alpha=0.3)
+    >>> plt.show()
+    """
+    # Convert to numpy array if necessary
+    if isinstance(data, pd.DataFrame):
+        if column is None:
+            raise ValueError("Column must be specified when data is a DataFrame")
+        values = data[column].values
+    else:
+        values = np.asarray(data)
+
+    # Calculate statistics
+    stats = {
+        "mean": np.mean(values),
+        "median": np.median(values),
+        "std": np.std(values),
+        "min": np.min(values),
+        "max": np.max(values),
+    }
+
+    return stats
+
+
+def solve_pendulum_ode(theta0=np.pi / 4, omega0=0, t_span=(0, 10), g=9.8, L=1.0):
+    """Solve the differential equation for a simple pendulum.
+
+    This function uses of mathematical equations in docstrings. ``jupyterlite-sphinx``
+    is able to convert LaTeX syntax for use with MathJax for rendering in the documentation.
+
+    Parameters
+    ----------
+    theta0 : float, default π/4
+        Initial angle in radians.
+    omega0 : float, default 0
+        Initial angular velocity in radians/second.
+    t_span : tuple of (float, float), default (0, 10)
+        Time interval (start, end) for the simulation.
+    g : float, default 9.8
+        Acceleration due to gravity in m/s².
+    L : float, default 1.0
+        Length of the pendulum in meters.
+
+    Returns
+    -------
+    tuple
+        (t, y) where t is the time points and y is the solution array with
+        columns [theta, omega].
+
+    Examples
+    --------
+    Simulate a damped harmonic oscillator, governed by the second-order
+    differential equation:
+
+    .. math::
+        \\frac{d^2\\theta}{dt^2} + \\frac{g}{L}\\sin(\\theta) = 0
+
+    where
+
+    1. :math:`\\theta` is the angle from the vertical position
+    2. :math:`g` is the acceleration due to gravity
+    3. :math:`L` is the length of the pendulum
+
+    >>> import numpy as np
+    >>> from scipy.integrate import solve_ivp
+    >>> import matplotlib.pyplot as plt
+    >>>
+    >>> def harmonic_oscillator(t, y, k=1.0, m=1.0, c=0.1):
+    ...     # Simple harmonic oscillator with damping
+    ...     # y[0] is position, y[1] is velocity
+    ...     return [y[1], -k/m * y[0] - c/m * y[1]]
+    >>>
+    >>> # Initial conditions: position = 1, velocity = 0
+    >>> y0 = [1.0, 0.0]
+    >>>
+    >>> ### Solving the ODE
+    >>> t_span = (0, 20)
+    >>> t_eval = np.linspace(t_span[0], t_span[1], 500)
+    >>> sol = solve_ivp(harmonic_oscillator, t_span, y0, method='RK45', t_eval=t_eval)
+    >>>
+    >>> ### Plotting the results
+    >>> plt.figure(figsize=(10, 6))
+    >>> plt.subplot(2, 1, 1)
+    >>> plt.plot(sol.t, sol.y[0])
+    >>> plt.title('Damped Harmonic Oscillator')
+    >>> plt.ylabel('Position')
+    >>> plt.grid(True)
+    >>>
+    >>> plt.subplot(2, 1, 2)
+    >>> plt.plot(sol.t, sol.y[1])
+    >>> plt.xlabel('Time (s)')
+    >>> plt.ylabel('Velocity')
+    >>> plt.grid(True)
+    >>> plt.tight_layout()
+    >>> plt.show()
+    >>>
+    >>> # A phase space plot
+    >>> plt.figure(figsize=(8, 8))
+    >>> plt.plot(sol.y[0], sol.y[1])
+    >>> plt.title('Phase Space')
+    >>> plt.xlabel('Position')
+    >>> plt.ylabel('Velocity')
+    >>> plt.grid(True)
+    >>> plt.axis('equal')
+    >>> plt.show()
+    """
+
+    def pendulum_system(t, y):
+        theta, omega = y
+        dydt = [omega, -(g / L) * np.sin(theta)]
+        return dydt
+
+    y0 = [theta0, omega0]
+    t_eval = np.linspace(t_span[0], t_span[1], 500)
+
+    sol = solve_ivp(pendulum_system, t_span, y0, method="RK45", t_eval=t_eval)
+
+    return sol.t, sol.y.T
+
+
+def image_processing(image):
+    """Process an image with various transformations.
+
+    This function has the TryExamples button explicitly disabled using
+    the '..! disable_try_examples::' comment at the beginning of the
+    Examples section.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image as a numpy array.
+
+    Returns
+    -------
+    dict
+        Dictionary containing various processed versions of the image.
+
+    Examples
+    --------
+
+    ..! disable_try_examples::
+
+    Generate and process synthetic images:
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from matplotlib.colors import LinearSegmentedColormap
+    >>>
+    >>> # Create a simple synthetic image
+    >>> x = np.linspace(-3, 3, 100)
+    >>> y = np.linspace(-3, 3, 100)
+    >>> X, Y = np.meshgrid(x, y)
+    >>> Z = np.sin(X) * np.cos(Y)
+    >>>
+    >>> # Display the image
+    >>> plt.figure(figsize=(12, 10))
+    >>> plt.subplot(2, 2, 1)
+    >>> plt.imshow(Z, cmap='viridis')
+    >>> plt.title('Original')
+    >>> plt.colorbar()
+    >>>
+    >>> ### Apply some transformations
+    >>> # 1. Add some noise
+    >>> Z_noisy = Z + np.random.normal(0, 0.2, Z.shape)
+    >>> plt.subplot(2, 2, 2)
+    >>> plt.imshow(Z_noisy, cmap='viridis')
+    >>> plt.title('With Noise')
+    >>> plt.colorbar()
+    >>>
+    >>> # 2. Apply a filter (for smoothing)
+    >>> from scipy.ndimage import gaussian_filter
+    >>> Z_smooth = gaussian_filter(Z, sigma=1)
+    >>> plt.subplot(2, 2, 3)
+    >>> plt.imshow(Z_smooth, cmap='viridis')
+    >>> plt.title('Smoothed')
+    >>> plt.colorbar()
+    >>>
+    >>> # 3. Perform edge detection
+    >>> from scipy.ndimage import sobel
+    >>> Z_edges = sobel(Z)
+    >>> plt.subplot(2, 2, 4)
+    >>> plt.imshow(Z_edges, cmap='gray')
+    >>> plt.title('Edges')
+    >>> plt.colorbar()
+    >>>
+    >>> plt.tight_layout()
+    >>> plt.show()
+    """
+    from skimage import color, filters
+
+    grayscale = color.rgb2gray(image)
+    blurred = filters.gaussian(image, sigma=2, multichannel=True)
+    edges = filters.sobel(grayscale)
+
+    return {"grayscale": grayscale, "blurred": blurred, "edges": edges}

--- a/xeus-kernel-example/docs/source/example.py
+++ b/xeus-kernel-example/docs/source/example.py
@@ -259,7 +259,7 @@ def image_processing(image):
     """Process an image with various transformations.
 
     This function has the TryExamples button explicitly disabled using
-    the '..! disable_try_examples::' comment at the beginning of the
+    the '..! disable_try_examples' comment at the beginning of the
     Examples section.
 
     Parameters
@@ -275,7 +275,7 @@ def image_processing(image):
     Examples
     --------
 
-    ..! disable_try_examples::
+    ..! disable_try_examples
 
     Generate and process synthetic images:
 

--- a/xeus-kernel-example/docs/source/index.md
+++ b/xeus-kernel-example/docs/source/index.md
@@ -16,4 +16,5 @@ The demo has been organised into the following sections, each of which demonstra
 :maxdepth: 1
 
 custom_contents/matplotlib_demo.md
+apiref.md
 ```

--- a/xeus-kernel-example/docs/source/try_examples.json
+++ b/xeus-kernel-example/docs/source/try_examples.json
@@ -1,0 +1,4 @@
+{
+  "global_min_height": "400px",
+  "ignore_patterns": ["disabled_examples\/demo.html"]
+}

--- a/xeus-kernel-example/requirements.txt
+++ b/xeus-kernel-example/requirements.txt
@@ -8,6 +8,8 @@ jupyterlite-sphinx
 # for more information.
 jupyterlite-xeus
 
+###############################################################################
+
 # The Sphinx documentation framework and our theme of choice: the PyData Sphinx Theme
 sphinx
 pydata-sphinx-theme
@@ -17,6 +19,12 @@ myst-nb
 
 # Dependencies we require for notebook execution
 matplotlib
+numpy
+scikit-image
+scipy
 
 # Dependencies we require for API reference generation
 numpydoc
+
+# Other Sphinx extensions
+sphinx-design

--- a/xeus-kernel-example/requirements.txt
+++ b/xeus-kernel-example/requirements.txt
@@ -1,6 +1,6 @@
 
 # jupyterlite-sphinx brings jupyterlite-core and JupyterLite-specific dependencies.
-jupyterlite-sphinx
+jupyterlite-sphinx>=0.20.0
 
 # The Xeus kernel is a loader for various JupyterLite-compatible kernels for several
 # languages. Kernels and additional dependencies are loaded from an environment.yml

--- a/xeus-kernel-example/requirements.txt
+++ b/xeus-kernel-example/requirements.txt
@@ -22,6 +22,7 @@ matplotlib
 numpy
 scikit-image
 scipy
+pandas
 
 # Dependencies we require for API reference generation
 numpydoc

--- a/xeus-kernel-example/requirements.txt
+++ b/xeus-kernel-example/requirements.txt
@@ -17,3 +17,6 @@ myst-nb
 
 # Dependencies we require for notebook execution
 matplotlib
+
+# Dependencies we require for API reference generation
+numpydoc


### PR DESCRIPTION
## Description

This PR adds some reference pages for the TryExamples directive and surrounding configuration, a page where examples are disabled, and the JSON configuration file.

Closes #5 