### PR TITLE
Install `micromamba` as `jupyterlite-xeus` v4 needs it to build WASM environments

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -40,11 +43,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install micromamba for Xeus kernel example site
+        uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc # v2.0.4
+        if: matrix.site[0] == 'xeus-kernel-example'
+
       - name: Install dependencies
         working-directory: ${{ matrix.site[0] }}
         run: pip install -r requirements.txt
 
-      - name: Build Sphinx site
+      - name: Build Sphinx {{ matrix.site[0] }} site
         working-directory: ${{ matrix.site[0] }}/docs
         run: make html
 

--- a/xeus-kernel-example/requirements.txt
+++ b/xeus-kernel-example/requirements.txt
@@ -4,8 +4,12 @@ jupyterlite-sphinx>=0.20.0
 
 # The Xeus kernel is a loader for various JupyterLite-compatible kernels for several
 # languages. Kernels and additional dependencies are loaded from an environment.yml
-# file, which is included in the docs/ folder. See https://jupyterlite-xeus.readthedocs.io/en/stable/
-# for more information.
+# file, which is included in the docs/ folder. For more information, see the docs at
+# https://jupyterlite-xeus.readthedocs.io/en/stable.
+# It requires micromamba for solving WASM environments, which has to be installed
+# on the system separately of this requirements file. This is not required for
+# conda-based development environment setups, as micromamba is a dependency of
+# the jupyterlite-xeus conda package and will be installed automatically.
 jupyterlite-xeus
 
 ###############################################################################


### PR DESCRIPTION
This PR addresses the build failure noticed from one of our scheduled workflow runs: https://github.com/jupyterlite/sphinx-demo/actions/runs/15431755414/job/43488565919.

The cause is the recent https://github.com/jupyterlite/xeus/releases/tag/v4.0.0 which introduced a breaking change: it is now either required to install `micromamba` when installing the Xeus kernel loader (only from `pip`, as `micromamba` doesn't exist on PyPI). The reason is that only micromamba is supported for creating Emscripten environments (see https://github.com/jupyterlite/xeus/issues/148 and the fix at https://github.com/jupyterlite/xeus/pull/200) because it's the only package manager variant in the conda packaging ecosystem that supports prefix relocation at the moment. It is not required to specify `micromamba` when installing from conda-forge, as `jupyterlite-xeus` depends on it.