### PR TITLE
Drop customisations for settings and contents storage names

### DIFF
--- a/pyodide-kernel-example/docs/source/jupyter-lite.json
+++ b/pyodide-kernel-example/docs/source/jupyter-lite.json
@@ -3,8 +3,6 @@
   "jupyter-config-data": {
     "appName": "jupyterlite-sphinx-demo (Pyodide)",
     "defaultKernelName": "python",
-    "faviconUrl": "./lab/favicon.ico",
-    "contentsStorageName": "jupyterlite-sphinx-demo (Pyodide)",
-    "settingsStorageName": "jupyterlite-sphinx-demo (Pyodide)"
+    "faviconUrl": "./lab/favicon.ico"
   }
 }

--- a/xeus-kernel-example/docs/source/jupyter-lite.json
+++ b/xeus-kernel-example/docs/source/jupyter-lite.json
@@ -3,8 +3,6 @@
   "jupyter-config-data": {
     "appName": "jupyterlite-sphinx-demo (Xeus)",
     "defaultKernelName": "XPython",
-    "faviconUrl": "./lab/favicon.ico",
-    "contentsStorageName": "jupyterlite-sphinx-demo (Xeus)",
-    "settingsStorageName": "jupyterlite-sphinx-demo (Xeus)"
+    "faviconUrl": "./lab/favicon.ico"
   }
 }


### PR DESCRIPTION
Closes #7; we no longer need to use these keys as JupyterLite now appends the `baseUrl` to the names, so multiple deployments on the same server can co-exist without their settings and storage contents being merged with each other.